### PR TITLE
Fixes to regexes

### DIFF
--- a/lib/virastar.rb
+++ b/lib/virastar.rb
@@ -68,7 +68,7 @@ module Virastar
       text.tr!(bad_chars,good_chars) if @fix_misc_non_persian_chars
 
       # should not replace exnglish chars in english phrases
-      text.gsub!(/([a-z\-_]{2,}[۰-۹]+|[۰-۹]+[a-z\-_]{2,})/i) do |s|
+      text.gsub!(/([a-zA-Z\-_]{2,}[۰-۹]+|[۰-۹]+[a-zA-Z\-_]{2,})/i) do |s|
         s.tr(persian_numbers,english_numbers)
       end
 
@@ -101,16 +101,16 @@ module Virastar
 
       # should fix outside and inside spacing for () [] {}  “” «»
       if @fix_spacing_for_braces_and_quotes
-        text.gsub!(/[   ‌]*(\()\s*([^)]+?)\s*?(\))[   ‌]*/,' \1\2\3 ')
-        text.gsub!(/[   ‌]*(\[)\s*([^)]+?)\s*?(\])[   ‌]*/,' \1\2\3 ')
-        text.gsub!(/[   ‌]*(\{)\s*([^)]+?)\s*?(\})[   ‌]*/,' \1\2\3 ')
-        text.gsub!(/[   ‌]*(“)\s*([^)]+?)\s*?(”)[   ‌]*/,' \1\2\3 ')
-        text.gsub!(/[   ‌]*(«)\s*([^)]+?)\s*?(»)[   ‌]*/,' \1\2\3 ')
+        text.gsub!(/[ \t‌]*(\()\s*([^)]+?)\s*?(\))[ \t‌]*/,' \1\2\3 ')
+        text.gsub!(/[ \t‌]*(\[)\s*([^\]]+?)\s*?(\])[ \t‌]*/,' \1\2\3 ')
+        text.gsub!(/[ \t‌]*(\{)\s*([^}]+?)\s*?(\})[ \t‌]*/,' \1\2\3 ')
+        text.gsub!(/[ \t‌]*(“)\s*([^”]+?)\s*?(”)[ \t‌]*/,' \1\2\3 ')
+        text.gsub!(/[ \t‌]*(«)\s*([^»]+?)\s*?(»)[ \t‌]*/,' \1\2\3 ')
       end
 
       # : ; , . ! ? and their persian equivalents should have one space after and no space before
       if @fix_spacing_for_braces_and_quotes
-        text.gsub!(/[ ‌  ]*([:;,؛،.؟!]{1})[ ‌  ]*/, '\1 ')
+        text.gsub!(/[ \t‌]*([:;,؛،.؟!]{1})[ \t‌]*/, '\1 ')
         # do not put space after colon that separates time parts
         text.gsub!(/([۰-۹]+):\s+([۰-۹]+)/, '\1:\2')
       end
@@ -118,16 +118,16 @@ module Virastar
       # should fix inside spacing for () [] {}  “” «»
       if @fix_spacing_for_braces_and_quotes
         text.gsub!(/(\()\s*([^)]+?)\s*?(\))/,'\1\2\3')
-        text.gsub!(/(\[)\s*([^)]+?)\s*?(\])/,'\1\2\3')
-        text.gsub!(/(\{)\s*([^)]+?)\s*?(\})/,'\1\2\3')
-        text.gsub!(/(“)\s*([^)]+?)\s*?(”)/,'\1\2\3')
-        text.gsub!(/(«)\s*([^)]+?)\s*?(»)/,'\1\2\3')
+        text.gsub!(/(\[)\s*([^\]]+?)\s*?(\])/,'\1\2\3')
+        text.gsub!(/(\{)\s*([^}]+?)\s*?(\})/,'\1\2\3')
+        text.gsub!(/(“)\s*([^”]+?)\s*?(”)/,'\1\2\3')
+        text.gsub!(/(«)\s*([^»]+?)\s*?(»)/,'\1\2\3')
       end
 
       # should replace more than one space with just a single one
       if @cleanup_spacing
         text.gsub!(/[ ]+/,' ')
-        text.gsub!(/([\n]+)[   ‌]*/,'\1')
+        text.gsub!(/([\n]+)[ \t‌]*/,'\1')
       end
 
       # remove spaces, tabs, and new lines from the beginning and enf of file

--- a/spec/virastar_spec.rb
+++ b/spec/virastar_spec.rb
@@ -122,6 +122,7 @@ describe Virastar do
   end
 
   it "should fix spacing for () [] {}  “” «» (one space outside, no space inside)" do
+    # matched brackets
     [ ["(",")"],["[","]"],["{","}"],["“","”"],["«","»"] ].each do |b|
       test  = "this is#{b[0]} a test#{b[1]}"
       test2 = "this is #{b[0]} a test  #{b[1]}"
@@ -136,6 +137,19 @@ describe Virastar do
       test3.persian_cleanup.should  == result3
       test4.persian_cleanup.should  == result4
     end
+    
+    # mismatched brackets
+    [ ["(","]"],["[",")"],["{","”"],["(","}"],["«","]"] ].each do |b|
+      test  = "mismatched brackets#{b[0]} don't apply#{b[1]}"
+      test2 = "mismatched brackets #{b[0]} don't apply #{b[1]}"
+      test3 = "mismatched brackets #{b[0]} don't apply #{b[1]} yeah!"
+      test4 = "mismatched brackets #{b[0]}don't apply #{b[1]} yeah!"
+      test.persian_cleanup.should   == test
+      test2.persian_cleanup.should  == test2
+      test3.persian_cleanup.should  == test3
+      test4.persian_cleanup.should  == test4
+    end
+    
   end
 
   it "should replace English percent sign to its Persian equivalent" do


### PR DESCRIPTION
It looks like several regexes dealing with spaces around brackets were buggy. Also, several regexes had multiple spaces within [ ] character class brackets. I assume that it was originally a tab and a space, and that a tab-to-spaces command was done at some point which caused the tab to be expanded to two spaces.
